### PR TITLE
Add method to create a *log.Logger backed by the package.

### DIFF
--- a/examples/httplog.go
+++ b/examples/httplog.go
@@ -25,7 +25,7 @@ func main() {
 	srv := &http.Server{
 		Addr:     ":8080",
 		Handler:  httplog.Middleware(logger, http.DefaultServeMux),
-		ErrorLog: logger.StdLogger(logger.Writer(logging.ErrorLevel)),
+		ErrorLog: logger.StdLogger(logging.ErrorLevel),
 	}
 
 	logger.Infof("start listening at %s.", srv.Addr)

--- a/examples/httplog.go
+++ b/examples/httplog.go
@@ -23,8 +23,9 @@ func main() {
 	})
 
 	srv := &http.Server{
-		Addr:    ":8080",
-		Handler: httplog.Middleware(logger, http.DefaultServeMux),
+		Addr:     ":8080",
+		Handler:  httplog.Middleware(logger, http.DefaultServeMux),
+		ErrorLog: logger.StdLogger(logger.Writer(logging.ErrorLevel)),
 	}
 
 	logger.Infof("start listening at %s.", srv.Addr)

--- a/logger.go
+++ b/logger.go
@@ -169,10 +169,10 @@ func (l *Logger) Writer(level Level) io.Writer {
 //  srv := &http.Server{
 //      Addr:     ":8080",
 //      Handler:  httplog.Middleware(logger, http.DefaultServeMux),
-//      ErrorLog: logger.StdLogger(logger.Writer(logging.ErrorLevel)),
+//      ErrorLog: logger.StdLogger(logging.ErrorLevel),
 //  }
-func (l *Logger) StdLogger(w io.Writer) *log.Logger {
-	return log.New(w, "", 0)
+func (l *Logger) StdLogger(level Level) *log.Logger {
+	return log.New(l.Writer(level), "", 0)
 }
 
 // Debug logs a message at debug level.

--- a/logger.go
+++ b/logger.go
@@ -154,8 +154,7 @@ func (l *Logger) TimeFormat() string {
 	return l.options.TimeFormat
 }
 
-// Writer returns a io.Writer for the given level. It is generally combined with
-// the Logger.StdLogger method.
+// Writer returns a io.Writer with the specified log level. 
 func (l *Logger) Writer(level Level) io.Writer {
 	return &writer{
 		Logger: l.Logger,
@@ -164,8 +163,7 @@ func (l *Logger) Writer(level Level) io.Writer {
 	}
 }
 
-// StdLogger returns a *log.Logger with the specified writer. The writer can be
-// created with the Logger.Writer method.
+// StdLogger returns a *log.Logger with the specified log level.
 //  srv := &http.Server{
 //      Addr:     ":8080",
 //      Handler:  httplog.Middleware(logger, http.DefaultServeMux),


### PR DESCRIPTION
### Description

This PR adds a method to create a `*log.Logger` backed by the package.

It can be used for example in the `http.Server.ErrorLog`:
```golang
srv := &http.Server{
    Addr:     ":8080",
    Handler:  httplog.Middleware(logger, http.DefaultServeMux),
    ErrorLog: logger.StdLogger(logging.ErrorLevel),
}
```