### PR TITLE
Allow to pass the logger name through the context

### DIFF
--- a/context.go
+++ b/context.go
@@ -61,11 +61,13 @@ func GetTraceparent(ctx context.Context) (*tracing.Traceparent, bool) {
 	return v, ok
 }
 
+// WithName returns a new context with the given name in the context. This name
+// will appear in the log entries that include the returning context.
 func WithName(ctx context.Context, name string) context.Context {
 	return context.WithValue(ctx, nameKey, name)
 }
 
-// GetNAme returns the log name from the context if it exists.
+// GetName returns the log name from the context if it exists.
 func GetName(ctx context.Context) (string, bool) {
 	v, ok := ctx.Value(nameKey).(string)
 	return v, ok

--- a/context.go
+++ b/context.go
@@ -9,8 +9,12 @@ import (
 
 type key int
 
-// traceheaderKey is the context key that should store the request identifier.
-const traceheaderKey key = iota
+const (
+	// traceheaderKey is the context key that should store the request identifier.
+	traceheaderKey key = iota
+	// nameKey is the context key used to stored the log name.
+	nameKey
+)
 
 // Tracing returns a new middleware that gets the given header and sets it in
 // the context so it can be written in the logger. If the header does not exists
@@ -51,8 +55,18 @@ func WithTraceparent(ctx context.Context, tp *tracing.Traceparent) context.Conte
 	return context.WithValue(ctx, traceheaderKey, tp)
 }
 
-// GetTracing returns the tracing id from the context if it exists.
+// GetTraceparent returns the tracing id from the context if it exists.
 func GetTraceparent(ctx context.Context) (*tracing.Traceparent, bool) {
 	v, ok := ctx.Value(traceheaderKey).(*tracing.Traceparent)
+	return v, ok
+}
+
+func WithName(ctx context.Context, name string) context.Context {
+	return context.WithValue(ctx, nameKey, name)
+}
+
+// GetNAme returns the log name from the context if it exists.
+func GetName(ctx context.Context) (string, bool) {
+	v, ok := ctx.Value(nameKey).(string)
 	return v, ok
 }

--- a/examples/httplog.go
+++ b/examples/httplog.go
@@ -10,7 +10,7 @@ import (
 )
 
 func main() {
-	logger, err := logging.New("scim",
+	logger, err := logging.New("saluter",
 		logging.WithLogResponses(),
 		logging.WithLogRequests(),
 	)

--- a/grpclog/server_logger.go
+++ b/grpclog/server_logger.go
@@ -49,14 +49,19 @@ func (l *serverLogger) Log(ctx context.Context, fullMethod string, t time.Time, 
 		service = parts[l-1]
 	}
 
-	var requestID, tracingID string
+	var name, requestID, tracingID string
+	if s, ok := logging.GetName(ctx); ok {
+		name = s
+	} else {
+		name = l.name
+	}
 	if tp, ok := logging.GetTraceparent(ctx); ok {
 		requestID = tp.TraceID()
 		tracingID = tp.String()
 	}
 
 	fields := []zap.Field{
-		zap.String("name", l.name),
+		zap.String("name", name),
 		zap.String("system", "grpc"),
 		zap.String("span.kind", "server"),
 		zap.String("grpc.package", pkg),
@@ -113,14 +118,19 @@ func (l *serverLogger) LogStream(ctx context.Context, fullMethod string, msg str
 		service = parts[l-1]
 	}
 
-	var requestID, tracingID string
+	var name, requestID, tracingID string
+	if s, ok := logging.GetName(ctx); ok {
+		name = s
+	} else {
+		name = l.name
+	}
 	if tp, ok := logging.GetTraceparent(ctx); ok {
 		requestID = tp.TraceID()
 		tracingID = tp.String()
 	}
 
 	fields := []zap.Field{
-		zap.String("name", l.name),
+		zap.String("name", name),
 		zap.String("system", "grpc"),
 		zap.String("span.kind", "server"),
 		zap.String("grpc.package", pkg),

--- a/httplog/handler.go
+++ b/httplog/handler.go
@@ -91,7 +91,12 @@ func (l *LoggerHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 // writeEntry writes to the Logger writer the request information in the logger.
 func (l *LoggerHandler) writeEntry(w ResponseLogger, r *http.Request, t time.Time, d time.Duration) {
 	ctx := r.Context()
-	var requestID, tracingID string
+	var name, requestID, tracingID string
+	if s, ok := logging.GetName(ctx); ok {
+		name = s
+	} else {
+		name = l.name
+	}
 	if tp, ok := logging.GetTraceparent(ctx); ok {
 		requestID = tp.TraceID()
 		tracingID = tp.String()
@@ -118,7 +123,7 @@ func (l *LoggerHandler) writeEntry(w ResponseLogger, r *http.Request, t time.Tim
 	status := w.StatusCode()
 
 	fields := []zap.Field{
-		zap.String("name", l.name),
+		zap.String("name", name),
 		zap.String("system", "http"),
 		zap.String("request-id", requestID),
 		zap.String("tracing-id", tracingID),


### PR DESCRIPTION
### Description

This PR allows to define a custom value for the `name` property through the request context. If it is not provided the logger default name would be used.