### PR TITLE
Consider $LOG_FORMAT & $LOG_LEVEL when initializing loggers

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -26,6 +26,53 @@ const (
 	FatalLevel
 )
 
+// MarshalText implements [encoding.TextMarshaler] for Level.
+func (l Level) MarshalText() ([]byte, error) {
+	return []byte(l.String()), nil
+}
+
+// String implements [fmt.Stringer] for Level.
+func (l Level) String() string {
+	switch l {
+	case DebugLevel:
+		return "debug"
+	case InfoLevel:
+		return "info"
+	case WarnLevel:
+		return "warn"
+	case ErrorLevel:
+		return "error"
+	case FatalLevel:
+		return "fatal"
+	default:
+		return fmt.Sprintf("Level(%d)", l)
+	}
+}
+
+func (l Level) toZapCoreLevel() zapcore.Level {
+	return zapcore.Level(l)
+}
+
+// UnmarshalText implements [encoding.TextUnmarshaler] for Level.
+func (l *Level) UnmarshalText(text []byte) error {
+	switch lit := strings.ToLower(string(text)); lit {
+	default:
+		return fmt.Errorf("invalid level: %q", lit)
+	case "debug":
+		*l = DebugLevel
+	case "info", "":
+		*l = InfoLevel
+	case "warn":
+		*l = WarnLevel
+	case "error":
+		*l = ErrorLevel
+	case "fatal":
+		*l = FatalLevel
+	}
+
+	return nil
+}
+
 // DefaultTraceHeader is the default header used as a trace id.
 const DefaultTraceHeader = "Traceparent"
 
@@ -97,16 +144,18 @@ func New(name string, opts ...Option) (*Logger, error) {
 		return nil, errors.Errorf("unsupported logger.format '%s'", o.Format)
 	}
 
+	minLogLevel := o.Level.toZapCoreLevel()
+
 	// Logs info and debug to stdout
 	outWriter := zapcore.Lock(os.Stdout)
 	outLevel := zap.LevelEnablerFunc(func(lvl zapcore.Level) bool {
-		return lvl >= o.Level && lvl < zapcore.WarnLevel
+		return lvl >= minLogLevel && lvl < zapcore.WarnLevel
 	})
 
 	// Logs warning and errors to stderr
 	errWriter := zapcore.Lock(os.Stderr)
 	errLevel := zap.LevelEnablerFunc(func(lvl zapcore.Level) bool {
-		return lvl >= o.Level && lvl >= zapcore.WarnLevel
+		return lvl >= minLogLevel && lvl >= zapcore.WarnLevel
 	})
 
 	// Create zap.Logger

--- a/logger.go
+++ b/logger.go
@@ -100,13 +100,13 @@ func New(name string, opts ...Option) (*Logger, error) {
 	// Logs info and debug to stdout
 	outWriter := zapcore.Lock(os.Stdout)
 	outLevel := zap.LevelEnablerFunc(func(lvl zapcore.Level) bool {
-		return lvl < zapcore.WarnLevel
+		return lvl >= o.Level && lvl < zapcore.WarnLevel
 	})
 
 	// Logs warning and errors to stderr
 	errWriter := zapcore.Lock(os.Stderr)
 	errLevel := zap.LevelEnablerFunc(func(lvl zapcore.Level) bool {
-		return lvl >= zapcore.WarnLevel
+		return lvl >= o.Level && lvl >= zapcore.WarnLevel
 	})
 
 	// Create zap.Logger

--- a/options.go
+++ b/options.go
@@ -2,25 +2,45 @@ package logging
 
 import (
 	"encoding/json"
+	"os"
 
 	"github.com/pkg/errors"
+	"go.uber.org/zap/zapcore"
 )
 
 type options struct {
-	Format       string `json:"format"`
-	TraceHeader  string `json:"traceHeader"`
-	LogRequests  bool   `json:"logRequests"`
-	LogResponses bool   `json:"logResponses"`
-	TimeFormat   string `json:"timeFormat"`
-	CallerSkip   int    `json:"callerSkip"`
+	Format       string        `json:"format"`
+	Level        zapcore.Level `json:"level"`
+	TraceHeader  string        `json:"traceHeader"`
+	LogRequests  bool          `json:"logRequests"`
+	LogResponses bool          `json:"logResponses"`
+	TimeFormat   string        `json:"timeFormat"`
+	CallerSkip   int           `json:"callerSkip"`
 }
 
 func defaultOptions() *options {
 	return &options{
-		Format:      "json",
+		Format:      formatFromEnv(),
+		Level:       levelFromEnv(),
 		TraceHeader: DefaultTraceHeader,
 		CallerSkip:  1,
 	}
+}
+
+func formatFromEnv() (format string) {
+	if format = os.Getenv("LOG_FORMAT"); format == "" {
+		format = "json"
+	}
+	return
+}
+
+func levelFromEnv() (level zapcore.Level) {
+	v := os.Getenv("LOG_LEVEL")
+	if err := level.UnmarshalText([]byte(v)); err != nil {
+		level = zapcore.InfoLevel
+	}
+
+	return
 }
 
 func (o *options) apply(opts []Option) (err error) {
@@ -98,6 +118,14 @@ func WithLogResponses() Option {
 func WithCallerSkip(skip int) Option {
 	return func(o *options) error {
 		o.CallerSkip = skip
+		return nil
+	}
+}
+
+// WithLogLevel sets the verbosity of the logger.
+func WithLogLevel(level zapcore.Level) Option {
+	return func(o *options) error {
+		o.Level = level
 		return nil
 	}
 }

--- a/options.go
+++ b/options.go
@@ -5,17 +5,16 @@ import (
 	"os"
 
 	"github.com/pkg/errors"
-	"go.uber.org/zap/zapcore"
 )
 
 type options struct {
-	Format       string        `json:"format"`
-	Level        zapcore.Level `json:"level"`
-	TraceHeader  string        `json:"traceHeader"`
-	LogRequests  bool          `json:"logRequests"`
-	LogResponses bool          `json:"logResponses"`
-	TimeFormat   string        `json:"timeFormat"`
-	CallerSkip   int           `json:"callerSkip"`
+	Format       string `json:"format"`
+	Level        Level  `json:"level"`
+	TraceHeader  string `json:"traceHeader"`
+	LogRequests  bool   `json:"logRequests"`
+	LogResponses bool   `json:"logResponses"`
+	TimeFormat   string `json:"timeFormat"`
+	CallerSkip   int    `json:"callerSkip"`
 }
 
 func defaultOptions() *options {
@@ -34,10 +33,10 @@ func formatFromEnv() (format string) {
 	return
 }
 
-func levelFromEnv() (level zapcore.Level) {
+func levelFromEnv() (level Level) {
 	v := os.Getenv("LOG_LEVEL")
 	if err := level.UnmarshalText([]byte(v)); err != nil {
-		level = zapcore.InfoLevel
+		level = InfoLevel
 	}
 
 	return
@@ -123,9 +122,10 @@ func WithCallerSkip(skip int) Option {
 }
 
 // WithLogLevel sets the verbosity of the logger.
-func WithLogLevel(level zapcore.Level) Option {
+func WithLogLevel(level Level) Option {
 	return func(o *options) error {
 		o.Level = level
+
 		return nil
 	}
 }


### PR DESCRIPTION
This PR refactors the codebase so that the `LOG_FORMAT` & `LOG_LEVEL` environment variables are taken into consideration when initializing loggers.