### PR TITLE
golangci-lint: fixed violations

### DIFF
--- a/encoder/clf_encoder.go
+++ b/encoder/clf_encoder.go
@@ -106,10 +106,10 @@ func (e *clfEncoder) EncodeEntry(entry zapcore.Entry, fields []zapcore.Field) (*
 }
 
 // Implementation of the zapcore.ObjectEncoder interface.
-func (e *clfEncoder) AddArray(key string, marshaler zapcore.ArrayMarshaler) error {
+func (e *clfEncoder) AddArray(string, zapcore.ArrayMarshaler) error {
 	return nil
 }
-func (e *clfEncoder) AddObject(key string, marshaler zapcore.ObjectMarshaler) error {
+func (e *clfEncoder) AddObject(string, zapcore.ObjectMarshaler) error {
 	return nil
 }
 
@@ -200,11 +200,11 @@ func (e *clfEncoder) AddUintptr(key string, value uintptr) { e.AddUint64(key, ui
 
 // AddReflected uses reflection to serialize arbitrary objects, so it can be
 // slow and allocation-heavy.
-func (e *clfEncoder) AddReflected(key string, value interface{}) error {
+func (e *clfEncoder) AddReflected(string, interface{}) error {
 	return nil
 }
 
 // OpenNamespace opens an isolated namespace where all subsequent fields will be
 // added. Applications can use namespaces to prevent key collisions when
 // injecting loggers into sub-components or third-party libraries.
-func (e *clfEncoder) OpenNamespace(key string) {}
+func (*clfEncoder) OpenNamespace(string) {}

--- a/encoder/object_encoder.go
+++ b/encoder/object_encoder.go
@@ -116,7 +116,7 @@ func (e *objectEncoder) AddReflected(key string, value interface{}) error {
 // OpenNamespace opens an isolated namespace where all subsequent fields will
 // be added. Applications can use namespaces to prevent key collisions when
 // injecting loggers into sub-components or third-party libraries.
-func (e *objectEncoder) OpenNamespace(key string) {}
+func (*objectEncoder) OpenNamespace(string) {}
 
 func (e *objectEncoder) AddFloat32(key string, value float32) { e.AddFloat64(key, float64(value)) }
 func (e *objectEncoder) AddInt(key string, value int)         { e.AddInt64(key, int64(value)) }

--- a/encoder/text_encoder.go
+++ b/encoder/text_encoder.go
@@ -176,7 +176,7 @@ func (e *textEncoder) AddUintptr(key string, value uintptr) { e.AddUint64(key, u
 
 // AddReflected uses reflection to serialize arbitrary objects, so it can be
 // slow and allocation-heavy.
-func (e *textEncoder) AddReflected(key string, value interface{}) error {
+func (e *textEncoder) AddReflected(_ string, value interface{}) error {
 	b, err := json.Marshal(value)
 	if err != nil {
 		return err
@@ -188,4 +188,4 @@ func (e *textEncoder) AddReflected(key string, value interface{}) error {
 // OpenNamespace opens an isolated namespace where all subsequent fields will be
 // added. Applications can use namespaces to prevent key collisions when
 // injecting loggers into sub-components or third-party libraries.
-func (e *textEncoder) OpenNamespace(key string) {}
+func (*textEncoder) OpenNamespace(string) {}


### PR DESCRIPTION
This PR fixes a few `golangci-lint` violations.

Necessary in order to fix the broken build of #39.