### PR TITLE
Add `k8s`, `kubernetes` and `docker` as accepted log formats

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -138,10 +138,10 @@ func New(name string, opts ...Option) (*Logger, error) {
 
 	var outEncoder, errEncoder zapcore.Encoder
 	switch strings.ToLower(o.Format) {
-	case "", "text":
+	case "", "text", "docker":
 		outEncoder = encoder.NewTextEncoder(config)
 		errEncoder = encoder.NewTextEncoder(config)
-	case "json":
+	case "json", "k8s", "kubernetes":
 		outEncoder = zapcore.NewJSONEncoder(config)
 		errEncoder = zapcore.NewJSONEncoder(config)
 	case "common":


### PR DESCRIPTION
To allow for interoperability with Panoramix logging in a single project, `smallstep/logging` now accepts the new Panoramix formats in addition to the existing ones. The actual formatting isn't changed; it merely accepts the values as valid formats.


This replaces https://github.com/smallstep/panoramix/pull/40. The benefit of adding them here is that we'll only need to update the library once. We don't need to change a deployment (in the future) to move from `PANORAMIX_LOG_FORMAT` to `LOG_FORMAT`.