### PR TITLE
Log propagated request ID and allow interoperability with legacy tracing

### DIFF
--- a/httplog/handler.go
+++ b/httplog/handler.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/smallstep/logging"
+	"github.com/smallstep/logging/requestid"
 	"go.uber.org/zap"
 )
 
@@ -105,7 +106,7 @@ func (l *LoggerHandler) writeEntry(w ResponseLogger, r *http.Request, t time.Tim
 	// Use (reflected) request ID for logging. It _could_ be empty if it wasn't set
 	// by some (external) middleware, but we stil log the legacy request ID too, so
 	// it shouldn't be too big of an issue.
-	requestID = w.Header().Get("X-Request-Id")
+	requestID = requestid.FromContext(ctx)
 
 	// Remote hostname
 	addr, _, err := net.SplitHostPort(r.RemoteAddr)

--- a/httplog/handler.go
+++ b/httplog/handler.go
@@ -91,16 +91,21 @@ func (l *LoggerHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 // writeEntry writes to the Logger writer the request information in the logger.
 func (l *LoggerHandler) writeEntry(w ResponseLogger, r *http.Request, t time.Time, d time.Duration) {
 	ctx := r.Context()
-	var name, requestID, tracingID string
+	var name, requestID, legacyRequestID, tracingID string
 	if s, ok := logging.GetName(ctx); ok {
 		name = s
 	} else {
 		name = l.name
 	}
 	if tp, ok := logging.GetTraceparent(ctx); ok {
-		requestID = tp.TraceID()
+		legacyRequestID = tp.TraceID()
 		tracingID = tp.String()
 	}
+
+	// Use (reflected) request ID for logging. It _could_ be empty if it wasn't set
+	// by some (external) middleware, but we stil log the legacy request ID too, so
+	// it shouldn't be too big of an issue.
+	requestID = w.Header().Get("X-Request-Id")
 
 	// Remote hostname
 	addr, _, err := net.SplitHostPort(r.RemoteAddr)
@@ -126,6 +131,7 @@ func (l *LoggerHandler) writeEntry(w ResponseLogger, r *http.Request, t time.Tim
 		zap.String("name", name),
 		zap.String("system", "http"),
 		zap.String("request-id", requestID),
+		zap.String("request-id-legacy", legacyRequestID),
 		zap.String("tracing-id", tracingID),
 		zap.String("remote-address", addr),
 		zap.String("time", t.Format(l.timeFormat)),

--- a/requestid/requestid.go
+++ b/requestid/requestid.go
@@ -1,0 +1,16 @@
+package requestid
+
+import "context"
+
+type contextKey struct{}
+
+func NewContext(ctx context.Context, requestID string) context.Context {
+	return context.WithValue(ctx, contextKey{}, requestID)
+}
+
+func FromContext(ctx context.Context) string {
+	if v, ok := ctx.Value(contextKey{}).(string); ok {
+		return v
+	}
+	return ""
+}


### PR DESCRIPTION
This adds a new `requestid` package, which can be used to propagate the request ID (using the new logic) to the legacy logging functionality. The old request ID will now be logged only if the new request ID could not be retrieved from the context.

It's likely this will only have to be used (by dependent systems) for a short while, since `panoramix` implements our new logging and tracing functionality. 