### PR TITLE
gh: aligned workflow permissions with smallstep/workflows#324

### DIFF
--- a/.github/workflows/actionci.yml
+++ b/.github/workflows/actionci.yml
@@ -16,6 +16,7 @@ jobs:
   actionci:
     permissions:
       contents: read
+      actions: read
       security-events: write
     uses: smallstep/workflows/.github/workflows/actionci.yml@main
     secrets: inherit

--- a/.github/workflows/code-scan-cron.yml
+++ b/.github/workflows/code-scan-cron.yml
@@ -2,13 +2,11 @@ on:
   schedule:
     - cron: '0 0 * * SUN'
 
-permissions:
-  actions: read
-  contents: read
-  security-events: write
-
 jobs:
   code-scan:
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
     uses: smallstep/workflows/.github/workflows/code-scan.yml@main
-    secrets:
-      GITLEAKS_LICENSE_KEY: ${{ secrets.GITLEAKS_LICENSE_KEY }}
+    secrets: inherit

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -15,6 +15,5 @@ jobs:
     permissions:
       contents: read
       issues: write
-      pull-requests: write
     uses: smallstep/workflows/.github/workflows/triage.yml@main
     secrets: inherit


### PR DESCRIPTION
This PR amends the workflows configuration to be more inline with smallstep/workflows#324.

It additionally drops `pull-requests: write` from the `triage` job in `triage.yml`, since the called workflow only labels via the issues API.
